### PR TITLE
Add pandas dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ MetaGenScope-CLI is used to upload data sets to the MetaGenScope web platform.
 """
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'requests', 'configparser']
+dependencies = ['click', 'requests', 'configparser', 'pandas']
 
 setup(
     name='metagenscope',


### PR DESCRIPTION
This allows `pip install -e [python-metagenscope path]` to work correctly for local development.